### PR TITLE
Fix -top 'n' when fewer than 'n' files are open.

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,8 +139,11 @@ func top(top int) {
 	stats := getStatsFromFiles(files)
 
 	sort.Sort(PcStatusList(stats))
-	topStats := stats[:top]
-	formatStats(topStats)
+
+        if len(stats) > top {
+                stats = stats[:top]
+        }
+        formatStats(stats)
 }
 
 func main() {


### PR DESCRIPTION
Fixes #1 

-top was crashing when given a very large number, this fixes it (when less than 'n' results, just show all results)

Before:
```
# hcache -top 50000
panic: runtime error: slice bounds out of range
```