### PR TITLE
Switch dir to inspect files opened by a specific process

### DIFF
--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 }
 
 func getPidMaps(pid int) []string {
-	fname := fmt.Sprintf("/proc/%d/maps", pid)
+	fname := fmt.Sprintf("/proc/%d/fd", pid)
 
 	f, err := os.Open(fname)
 	if err != nil {


### PR DESCRIPTION
Previously it inspect files opened by the process in /proc/{pid}/maps. Now it inspect files opened by the process in /proc/{pid}/fd.